### PR TITLE
Add some pre-val for Impact for import4

### DIFF
--- a/src/zenoss/toolbox/import4tools/__init__.py
+++ b/src/zenoss/toolbox/import4tools/__init__.py
@@ -11,8 +11,14 @@ import logging
 import sys
 
 
+def setupLogger(loggerName):
+    log = logging.getLogger(loggerName)
+    log.setLevel(logging.INFO)
+    return log
+
 logging.basicConfig(
     stream=sys.stdout,
     level=logging.INFO,
     format='%(asctime)s %(levelname)s %(name)s: %(message)s')
-log = logging.getLogger(__name__)
+
+log = setupLogger(__name__)

--- a/src/zenoss/toolbox/import4tools/validate4import.py
+++ b/src/zenoss/toolbox/import4tools/validate4import.py
@@ -15,13 +15,14 @@ scriptVersion = "0.9"
 # to this process, subclass Import4Validation in the validations library and
 # add it to the validation library's `__all__` attribute
 
+from . import setupLogger
 from validations import *
 
 from argparse import ArgumentParser
 import sys
 import logging
 
-log = logging.getLogger(__name__)
+log = setupLogger(__name__)
 
 
 class ValidationRunner(object):

--- a/src/zenoss/toolbox/import4tools/validations/ImpactValidation.py
+++ b/src/zenoss/toolbox/import4tools/validations/ImpactValidation.py
@@ -1,0 +1,50 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+#!/opt/zenoss/bin/python
+
+from . import Import4Validation, ValidationException
+from .. import setupLogger
+
+import Globals
+from Products.ZenUtils.ZenScriptBase import ZenScriptBase
+
+from pkg_resources import parse_version
+
+log = setupLogger(__name__)
+
+MIN_ZP_VERS = '4.2.6'
+
+class ImpactValidation(Import4Validation):
+    """
+    Validate that the currently installed version of Impact is compatible for
+    export/import
+    """
+    @staticmethod
+    def _add_parser(subparsers):
+        parser = subparsers.add_parser('impact',
+                                       description='Run validations against ' \
+                                                   'Impact')
+        return parser
+
+    def validate(self, argz):
+        dmd = ZenScriptBase(noopts=True, connect=True).dmd
+        impactPack = dmd.ZenPackManager.packs.findObjectsById('ZenPacks.zenoss.Impact')
+        if not impactPack:
+            log.info('The Impact ZenPack is not installed')
+            return
+
+        impactPack = impactPack[0]
+        if cmp(parse_version(impactPack.version), parse_version(MIN_ZP_VERS)) > 0:
+            log.info('Impact ZenPack version %s is installed, OK to migrate', impactPack.version)
+            return
+
+        log.error('ZenPacks.zenoss.Impact is at version %s, but must be ' \
+                  'at least version %s, exiting', impactPack.version, MIN_ZP_VERS)
+        raise ValidationException()

--- a/src/zenoss/toolbox/import4tools/validations/ZenPackValidation.py
+++ b/src/zenoss/toolbox/import4tools/validations/ZenPackValidation.py
@@ -10,6 +10,7 @@
 #!/opt/zenoss/bin/python
 
 from . import Import4Validation, ValidationException
+from .. import setupLogger
 
 import Globals
 from Products.ZenUtils.ZenScriptBase import ZenScriptBase
@@ -18,9 +19,8 @@ from pkg_resources import parse_version
 import os
 import inspect
 import json
-import logging
 
-log = logging.getLogger(__name__)
+log = setupLogger(__name__)
 
 MANIFEST_FILE = 'packmanifest.json'
 

--- a/src/zenoss/toolbox/import4tools/validations/__init__.py
+++ b/src/zenoss/toolbox/import4tools/validations/__init__.py
@@ -7,16 +7,17 @@
 #
 ##############################################################################
 
-import logging
+from .. import setupLogger
 
-log = logging.getLogger(__name__)
+log = setupLogger(__name__)
 
 # Whenever a validation is created, it's class needs to be added to this list
 __all__ = [
     'ValidationException',
     'Import4Validation',
 
-    'ZenPackValidation'
+    'ZenPackValidation',
+    'ImpactValidation'
 ]
 
 class ValidationException(Exception):


### PR DESCRIPTION
```
[zenoss@migration-424-source validations]$ validate4import impact
2015-05-07 10:13:08,224 INFO zenoss.toolbox.import4tools.validate4import: Starting validation ImpactValidation
2015-05-07 10:13:14,920 INFO zenoss.toolbox.import4tools.validations.ImpactValidation: Impact ZenPack version 4.2.6.0.3 is installed, OK to migrate
2015-05-07 10:13:14,921 INFO zenoss.toolbox.import4tools.validate4import: Validation successful
```